### PR TITLE
Simplify the `bel_proper_list_p` function

### DIFF
--- a/believe-literate.org
+++ b/believe-literate.org
@@ -910,14 +910,11 @@ bel_proper_list_p(Bel *x)
     if(!bel_pairp(x))
         return 0;
     
-    if(bel_nilp(x))
-        return 1;
-    
     Bel *itr = x;
     while(!bel_nilp(itr)) {
-        itr = bel_cdr(itr);
         if(!bel_pairp(x))
             return 0;
+        itr = bel_cdr(itr);
     }
 
     return 1;


### PR DESCRIPTION
We can eliminate one conditional by re-ordering the test and
stepping the iterator inside the loop.