### PR TITLE
Change error message to "Too few"

### DIFF
--- a/believe-literate.org
+++ b/believe-literate.org
@@ -3931,7 +3931,7 @@ bel_bind(Bel *vars, Bel *vals, Bel *lenv)
 
     if(vars_ended && !vals_ended) {
         return bel_mkerror(
-            bel_mkstring("Too many variables in "
+            bel_mkstring("Too few variables in "
                          "function application"),
             bel_g_nil);
     } else if(!vars_ended && vals_ended) {


### PR DESCRIPTION
The condition above the message makes it clear that the message
should be this. I guess "Too many values" would also work.